### PR TITLE
CMake: adopt CMAKE_INSTALL_<dir> for install locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ cmake_minimum_required(VERSION 3.3)
 
 project(WPEFrameworkUI)
 
+include(GNUInstallDirs)
+
 set(NPM "${NPM_BINARY_PATH}npm")
 
 option(AUDIT_AND_FIX "Automatic fix vulnerabilities where possible" OFF)
@@ -44,6 +46,6 @@ if(AUDIT_AND_FIX)
 endif()
 
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/dist/"
-    DESTINATION share/WPEFramework/Controller/UI
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/WPEFramework/Controller/UI
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ 
 )


### PR DESCRIPTION
When playing around with a multilib environment, I noticed that if our libs are built 64bit, those libs end up in (/usr/lib) aka  /usr/lib32. This is caused because we hardcode all the install locations. Let us leverage the use of GNUInstallDirs to dynamically install binaries to the default install locations set by build systems and package generators.

This PR is part of a series of PR's
https://github.com/rdkcentral/Thunder/pull/1604
https://github.com/rdkcentral/ThunderTools/pull/93
https://github.com/rdkcentral/ThunderInterfaces/pull/347
https://github.com/rdkcentral/ThunderClientLibraries/pull/257
https://github.com/rdkcentral/ThunderNanoServices/pull/789
https://github.com/WebPlatformForEmbedded/ThunderNanoServicesRDK/pull/301
https://github.com/WebPlatformForEmbedded/ThunderLibraries/pull/39

