### PR TITLE
[index.html] workaround for loading bundle.js no longer needed

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -25,8 +25,5 @@
 
 		<script src="bundle.js"></script>
 		<script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js"></script>
-		<!-- note this wont work locally, but for some odd reason Thunder serves everything from UI/ -->
-		<!-- this should be correct in thunder, but until that time ¯\_(ツ)_/¯ -->
-		<script src="UI/bundle.js"></script>
 	</body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -25,8 +25,5 @@
 
 		<script src="bundle.js"></script>
 		<script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js"></script>
-		<!-- note this wont work locally, but for some odd reason Thunder serves everything from UI/ -->
-		<!-- this should be correct in thunder, but until that time ¯\_(ツ)_/¯ -->
-		<script src="UI/bundle.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Do certainly not merge before:

https://github.com/rdkcentral/Thunder/pull/1848
and 

https://github.com/rdkcentral/Thunder/pull/1847

are merged!!

(and perhaps we should wait a little longer in case people are using older configs)

